### PR TITLE
replacing celery task with celery shared_task

### DIFF
--- a/edx_username_changer/tasks.py
+++ b/edx_username_changer/tasks.py
@@ -1,7 +1,7 @@
 """
 This file contains celery tasks related to edx_username_changer plugin.
 """
-from celery import task
+from celery import shared_task
 
 from django.contrib.auth import get_user_model
 
@@ -23,7 +23,7 @@ THREAD_TYPE = "thread"
 User = get_user_model()
 
 
-@task()
+@shared_task()
 def task_update_username_in_forum(username):
     """
     Changes username in Discussion-Forum service


### PR DESCRIPTION
### Related Issue
https://sentry.io/organizations/mit-office-of-digital-learning/issues/2368803648/?project=1730882&referrer=slack

### What does this PR do?
It replaces celery task with shared_task.

### Related context
https://openedx.atlassian.net/browse/BOM-2179
https://github.com/edx/edx-platform/pull/25954
https://docs.celeryproject.org/en/latest/django/first-steps-with-django.html#using-the-shared-task-decorator