### PR TITLE
Wait for the transaction to be committed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -10,7 +10,7 @@ certifi==2021.5.30
     # via requests
 charset-normalizer==2.0.6
     # via requests
-codecov==2.1.12
+codecov==2.1.13
     # via -r requirements/ci.in
 coverage==6.0.1
     # via codecov


### PR DESCRIPTION
Wait for the transaction to be committed before getting the user with new username


#### What are the relevant tickets?
fixes: https://github.com/mitodl/hq/issues/5584

#### What's this PR do?
It will wait for the transaction to be commit then we'll get the User with new username

#### How should this be manually tested?
- Change Username from edX
- New username should be reflected on edX other services e.g; discussion forums

#### Any background context you want to provide?
https://mit-office-of-digital-learning.sentry.io/issues/5869178614/?environment=mitxonline-production&project=5939801&query=is:unresolved%20issue.priority:%5Bhigh,%20medium%5D%20task_update_username_in_forum&sort=date&statsPeriod=90d&stream_index=0&utc=true
